### PR TITLE
fix(colors): nvim-treesitter

### DIFF
--- a/colors/highlite.lua
+++ b/colors/highlite.lua
@@ -857,12 +857,12 @@ local highlight_groups = {
 	NERDTreeLinkTarget = 'Tag',
 
 	--[[ 4.4.8. nvim-treesitter ]]
-	TSConstBuiltin = 'TSConstant',
-	TSConstructor = 'TSFunction',
-	TSDanger = 'ErrorMsg',
-	TSFuncBuiltin = 'TSFunction',
-	TSTag = 'Tag',
-	TSWarning = 'WarningMsg',
+	['@constant.builtin'] = '@constant',
+	['@constructor'] = '@function',
+	['@text.danger'] = 'ErrorMsg',
+	['@function.builtin'] = '@function',
+	['@tag'] = 'Tag',
+	['@text.warning'] = 'WarningMsg',
 
 	--[[ 4.4.9. barbar.nvim ]]
 	BufferAlternate       = function(self) return {fg = self.BufferVisible.fg, bg = gray_dark} end,


### PR DESCRIPTION
With nvim updating to 0.8, it adds more support to treesitter. 

Now, nvim-treesitter uses the nvim build-in hl-groups to highlight the treesitter parsers.  TS* highlight group is removed.

So update the treesitter hl-group to make it work.

https://github.com/nvim-treesitter/nvim-treesitter/pull/3656