### PR TITLE
fix(groups): `Comment` group derived from `text_contrast_bg_low` color

### DIFF
--- a/lua/highlite/groups/default.lua
+++ b/lua/highlite/groups/default.lua
@@ -85,7 +85,7 @@ local function from_palette(palette, opts)
 		Float = {fg = palette.float},
 
 		-- Syntax
-		Comment = {fg = palette.text_contrast_bg_low, italic = true},
+		Comment = {fg = palette.comment, italic = true},
 		Conditional = conditional,
 		Debug = 'WarningMsg',
 		Delimiter = delimiter,


### PR DESCRIPTION
It seems that, instead of using the dedicated `comment` color in the palette, it was derived from the `text_contrast_bg_low` color directly.

This commit amends that mistake: it should not be seen as a breaking change, as it was always meant to be used this way, and by default, `comment` _is_ `text_contrast_bg_low`.

Closes #35